### PR TITLE
fix: format parser messes up blank padding formats

### DIFF
--- a/lib/semantic_date_time_tags/format_parser.rb
+++ b/lib/semantic_date_time_tags/format_parser.rb
@@ -16,7 +16,7 @@ module SemanticDateTimeTags
         formatting_components.flatten.inject("") do |res, comp|
           regexp = Regexp.new(get_regexp_for_component(comp))
           if match = processed_str.match(regexp)
-            res += get_tag_for_match(match[0], comp)
+            res += get_tag_for_match(match[1], comp)
             processed_str = processed_str[match[0].length..-1]
           end
           res
@@ -41,6 +41,7 @@ module SemanticDateTimeTags
 
       def get_regexp_for_component(comp)
         case comp
+        when /%e/ then "\s([[:word:]]+)"
         when /%-?[[:word:]]/ then "([[:word:]]+)"
         else "(#{comp})"
         end

--- a/lib/semantic_date_time_tags/format_parser.rb
+++ b/lib/semantic_date_time_tags/format_parser.rb
@@ -41,7 +41,7 @@ module SemanticDateTimeTags
 
       def get_regexp_for_component(comp)
         case comp
-        when /%-?[ekl]/ then "\\s([[:word:]]+)"
+        when /%-?[ekl]/ then "\\s?([[:word:]]+)"
         when /%-?[[:word:]]/ then "([[:word:]]+)"
         else "(#{comp})"
         end

--- a/lib/semantic_date_time_tags/format_parser.rb
+++ b/lib/semantic_date_time_tags/format_parser.rb
@@ -41,7 +41,7 @@ module SemanticDateTimeTags
 
       def get_regexp_for_component(comp)
         case comp
-        when /%e/ then "\s([[:word:]]+)"
+        when /%-?[ekl]/ then "\\s([[:word:]]+)"
         when /%-?[[:word:]]/ then "([[:word:]]+)"
         else "(#{comp})"
         end
@@ -52,7 +52,7 @@ module SemanticDateTimeTags
         when /%-?[YCy]/ then [ "year", comp[/[[:word:]]/] ]
         when /%-?[mBbh]/ then [ "month", comp[/[[:word:]]/] ]
         when /%-?[aAdej]/ then [ "day", comp[/[[:word:]]/] ]
-        when /%-?[HKIl]/ then [ "hours", comp[/[[:word:]]/] ]
+        when /%-?[HkKIl]/ then [ "hours", comp[/[[:word:]]/] ]
         when /%-?[M]/ then [ "minutes", comp[/[[:word:]]/] ]
         when /%-?[pP]/ then [ "ampm", comp[/[[:word:]]/] ]
         when /\W+/ then [ "sep" ]

--- a/test/semantic_date_time_tags/format_parser_test.rb
+++ b/test/semantic_date_time_tags/format_parser_test.rb
@@ -81,23 +81,50 @@ describe SemanticDateTimeTags::FormatParser do
     end
 
     describe "blank padded formats" do
-      it "handles %e" do
-        format = "%a, %e %b, %Y %H:%M"
-        string = "Thu,  3 Apr, 2025 20:30"
-        _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).wont_match(/\<span class\=\"str\">0\<\/span\>/)
+      # Day of the month (1..31)
+      describe "%e" do
+        it "handles blank paddded results" do
+          format = "%a, %e %b, %Y %H:%M"
+          string = "Thu,  3 Apr, 2025 20:30"
+          _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).wont_match(/\<span class\=\"str\">0\<\/span\>/)
+        end
+
+        it "handles non blank padded results" do
+          date = Date.new(2025, 4, 30)
+          format = "%e %b, %Y"
+          string = I18n.localize(date, format: format)
+          _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).must_equal '<span class="day e">30</span><span class="sep"> </span><span class="month b">Apr</span><span class="sep">, </span><span class="year Y">2025</span>'
+        end
       end
 
-      it "handles %k" do
-        format = "%d.%m.%Y %k:%M"
-        string = "03.04.2025  4:30"
-        pp I18n.localize(DateTime.new(2025, 4, 3, 4, 30), format: format)
-        _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).must_equal '<span class="day d">03</span><span class="sep">.</span><span class="month m">04</span><span class="sep">.</span><span class="year Y">2025</span><span class="sep"> </span><span class="hours k">4</span><span class="sep">:</span><span class="minutes M">30</span>'
+      # Hour of the day, 24-hour clock
+      describe "%k" do
+        it "handles blank padded results" do
+          format = "%d.%m.%Y %k:%M"
+          string = "03.04.2025  4:30"
+          _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).must_equal '<span class="day d">03</span><span class="sep">.</span><span class="month m">04</span><span class="sep">.</span><span class="year Y">2025</span><span class="sep"> </span><span class="hours k">4</span><span class="sep">:</span><span class="minutes M">30</span>'
+        end
+
+        it "handles non blank padded results" do
+          format = "%d.%m.%Y %k:%M"
+          string = "03.04.2025 10:30"
+          _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).must_equal '<span class="day d">03</span><span class="sep">.</span><span class="month m">04</span><span class="sep">.</span><span class="year Y">2025</span><span class="sep"> </span><span class="hours k">10</span><span class="sep">:</span><span class="minutes M">30</span>'
+        end
       end
 
-      it "handles %l" do
-        format = "%d.%m.%Y %l:%M"
-        string = "03.04.2025  8:30"
-        _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).must_equal '<span class="day d">03</span><span class="sep">.</span><span class="month m">04</span><span class="sep">.</span><span class="year Y">2025</span><span class="sep"> </span><span class="hours l">8</span><span class="sep">:</span><span class="minutes M">30</span>'
+      # Hour of the day, 12-hour clock
+      describe "%l" do
+        it "handles blank padded results" do
+          format = "%d.%m.%Y %l.%M %P"
+          string = "03.04.2025  8.30 pm"
+          _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).must_equal '<span class="day d">03</span><span class="sep">.</span><span class="month m">04</span><span class="sep">.</span><span class="year Y">2025</span><span class="sep"> </span><span class="hours l">8</span><span class="sep">.</span><span class="minutes M">30</span><span class="sep"> </span><span class="ampm P">pm</span>'
+        end
+
+        it "handles non blank padded results" do
+          format = "%d.%m.%Y %l.%M %P"
+          string = "03.04.2025 10.30 am"
+          _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).must_equal '<span class="day d">03</span><span class="sep">.</span><span class="month m">04</span><span class="sep">.</span><span class="year Y">2025</span><span class="sep"> </span><span class="hours l">10</span><span class="sep">.</span><span class="minutes M">30</span><span class="sep"> </span><span class="ampm P">am</span>'
+        end
       end
     end
   end

--- a/test/semantic_date_time_tags/format_parser_test.rb
+++ b/test/semantic_date_time_tags/format_parser_test.rb
@@ -37,7 +37,7 @@ describe SemanticDateTimeTags::FormatParser do
 
     describe "d / m / Y" do
       let(:format) { "%a, %b %e, %Y" }
-      let(:string) { "Sun, Jan 1, 2015" }
+      let(:string) { "Sun, Jan  1, 2015" }
 
       it "wraps the components into span tags" do
         _(to_html).must_equal '<span class="day a">Sun</span><span class="sep">, </span><span class="month b">Jan</span><span class="sep"> </span><span class="day e">1</span><span class="sep">, </span><span class="year Y">2015</span>'
@@ -78,6 +78,12 @@ describe SemanticDateTimeTags::FormatParser do
       it "preserves additional strings" do
         _(to_html).must_equal "<span class=\"day d\">09</span><span class=\"sep\">.</span><span class=\"month m\">09</span><span class=\"sep\">.</span><span class=\"year Y\">2014</span><span class=\"sep\"> </span><span class=\"hours H\">19</span><span class=\"sep\">.</span><span class=\"minutes M\">00</span><span class=\"str\"> hrs</span>"
       end
+    end
+
+    it "does not add extra 0 to the output" do
+      format = "%a, %e %b, %Y %H:%M"
+      string = "Thu,  3 Apr, 2025 20:30"
+      _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).wont_match(/\<span class\=\"str\">0\<\/span\>/)
     end
   end
 end

--- a/test/semantic_date_time_tags/format_parser_test.rb
+++ b/test/semantic_date_time_tags/format_parser_test.rb
@@ -80,10 +80,25 @@ describe SemanticDateTimeTags::FormatParser do
       end
     end
 
-    it "does not add extra 0 to the output" do
-      format = "%a, %e %b, %Y %H:%M"
-      string = "Thu,  3 Apr, 2025 20:30"
-      _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).wont_match(/\<span class\=\"str\">0\<\/span\>/)
+    describe "blank padded formats" do
+      it "handles %e" do
+        format = "%a, %e %b, %Y %H:%M"
+        string = "Thu,  3 Apr, 2025 20:30"
+        _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).wont_match(/\<span class\=\"str\">0\<\/span\>/)
+      end
+
+      it "handles %k" do
+        format = "%d.%m.%Y %k:%M"
+        string = "03.04.2025  4:30"
+        pp I18n.localize(DateTime.new(2025, 4, 3, 4, 30), format: format)
+        _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).must_equal '<span class="day d">03</span><span class="sep">.</span><span class="month m">04</span><span class="sep">.</span><span class="year Y">2025</span><span class="sep"> </span><span class="hours k">4</span><span class="sep">:</span><span class="minutes M">30</span>'
+      end
+
+      it "handles %l" do
+        format = "%d.%m.%Y %l:%M"
+        string = "03.04.2025  8:30"
+        _(SemanticDateTimeTags::FormatParser.new(format, string).to_html).must_equal '<span class="day d">03</span><span class="sep">.</span><span class="month m">04</span><span class="sep">.</span><span class="year Y">2025</span><span class="sep"> </span><span class="hours l">8</span><span class="sep">:</span><span class="minutes M">30</span>'
+      end
     end
   end
 end


### PR DESCRIPTION
The format parser was not taking the extra whitespace into account when using blank padded formatting options `%e`, `%k` and `%l`. This would result in strange outputs in certain cases.